### PR TITLE
use request headers instead of query parameter for access token

### DIFF
--- a/ds-download.py
+++ b/ds-download.py
@@ -19,14 +19,13 @@ from urllib.parse import unquote
 # Obtenir les numéros des dossiers d'une procédure
 def get_numeros_dossiers():
     url = URL_API + 'procedures/' + PROCEDURE + '/dossiers?token=' + TOKEN
-    return [e['id'] for e in requests.get(url).json()['dossiers']]
+    return [e['id'] for e in requests.get(url, headers={'Authorization': 'Bearer {}'.format(TOKEN)}).json()['dossiers']]
 
 # Obtenir des les informations d'un dossier
 def get_dossier(numero):
     url_part1 = URL_API + 'procedures/' + PROCEDURE + '/dossiers/'
-    url_part2 = '?token=' + TOKEN
-    url = url_part1 + str(numero) + url_part2
-    return requests.get(url).json()
+    url = url_part1 + str(numero)
+    return requests.get(url, headers={'Authorization': 'Bearer {}'.format(TOKEN)}).json()
 
 # création d'une liste des positions des préfixes
 def positions_prefixes(champs):


### PR DESCRIPTION
Bonjour,  je travaille sur DS, bien joué pour ce travail !
Je n'ai pas tout relu, mais on préconise de fournir le token via un header plutôt que directement dans l'url, car cela présente un risque de sécurité pour vos procédures.
Si notre serveur est compromis, vos dossiers le seront aussi ; les headers ne sont pas stockés dans les logs du serveur, par contre les URL si, donc un attaquant pourra retrouver vos tokens même s'il n'a pas accès à la base de données.